### PR TITLE
feat: add support for default config file discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ $ gostyle run --config=.gostyle.yml ./...
 $ go vet -vettool=`which gostyle` -gostyle.config=$PWD/.gostyle.yml ./...
 ```
 
+> [!NOTE]
+> If no configuration file is specified, `gostyle` will automatically search for `.gostyle.yml` or `.gostyle.yaml` in the Git root directory.
+
 ```yaml
 # All available settings of specific analyzers.
 analyzers-settings:


### PR DESCRIPTION
This pull request enhances the configuration loading logic in `config/loader.go` to improve how the application locates and validates its configuration file. The main changes add support for automatic discovery of config files by searching parent directories for a `.git` folder and recognized config filenames, and improve path validation.

**Automatic config file discovery and path validation improvements:**

* Added logic to automatically search for `.gostyle.yml` or `.gostyle.yaml` in the nearest parent directory containing a `.git` folder when `configPath` is not explicitly provided. This makes configuration setup easier and more robust. [[1]](diffhunk://#diff-bc9700724b69674859b613197d5f1f5686984e538e21143037b1eb49e33facd3R19-R22) [[2]](diffhunk://#diff-bc9700724b69674859b613197d5f1f5686984e538e21143037b1eb49e33facd3R34-R60)
* Improved config path validation by requiring the config file path to be absolute using `filepath.IsAbs`, replacing the previous string prefix check. This ensures more reliable path handling across platforms.

**Code cleanup:**

* Removed the unnecessary import of the `strings` package since it is no longer used.